### PR TITLE
feat: 재고 조회 API 구현 (엔티티, 서비스, 컨트롤러, 테스트 추가)

### DIFF
--- a/src/main/java/com/gearfirst/backend/api/inventory/controller/InventoryController.java
+++ b/src/main/java/com/gearfirst/backend/api/inventory/controller/InventoryController.java
@@ -1,0 +1,45 @@
+package com.gearfirst.backend.api.inventory.controller;
+
+import com.gearfirst.backend.api.inventory.dto.InventoryResponse;
+import com.gearfirst.backend.api.inventory.entity.Inventory;
+import com.gearfirst.backend.api.inventory.service.InventoryService;
+import com.gearfirst.backend.common.response.ApiResponse;
+import com.gearfirst.backend.common.response.SuccessStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/api/v1/inventory")
+@RequiredArgsConstructor
+public class InventoryController {
+
+    private final InventoryService inventoryService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<InventoryResponse>>> getInventories(
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate) {
+
+        List<Inventory> inventories = inventoryService.getInventories(startDate, endDate);
+        List<InventoryResponse> responses = inventories.stream()
+                .map(InventoryResponse::fromEntity)
+                .collect(Collectors.toList());
+
+        return ApiResponse.success(SuccessStatus.GET_INVENTORY_LIST_SUCCESS, responses);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ApiResponse<InventoryResponse>> getInventory(@PathVariable Long id) {
+        Inventory inventory = inventoryService.getInventory(id);
+        InventoryResponse response = InventoryResponse.fromEntity(inventory);
+
+        return ApiResponse.success(SuccessStatus.GET_INVENTORY_SUCCESS, response);
+    }
+}

--- a/src/main/java/com/gearfirst/backend/api/inventory/dto/InventoryResponse.java
+++ b/src/main/java/com/gearfirst/backend/api/inventory/dto/InventoryResponse.java
@@ -1,0 +1,33 @@
+package com.gearfirst.backend.api.inventory.dto;
+
+import com.gearfirst.backend.api.inventory.entity.Inventory;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@AllArgsConstructor
+public class InventoryResponse {
+    private Long id;
+    private String inventoryName;
+    private String inventoryCode;
+    private int currentStock;
+    private int availableStock;
+    private String warehouse;
+    private LocalDateTime inboundDate;
+    private String inventoryStatus;
+
+    public static InventoryResponse fromEntity(Inventory inventory) {
+        return new InventoryResponse(
+                inventory.getId(),
+                inventory.getInventoryName(),
+                inventory.getInventoryCode(),
+                inventory.getCurrentStock(),
+                inventory.getAvailableStock(),
+                inventory.getWarehouse(),
+                inventory.getInboundDate(),
+                inventory.getInventoryStatus().name()
+        );
+    }
+}

--- a/src/main/java/com/gearfirst/backend/api/inventory/entity/Inventory.java
+++ b/src/main/java/com/gearfirst/backend/api/inventory/entity/Inventory.java
@@ -1,0 +1,86 @@
+package com.gearfirst.backend.api.inventory.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "inventory")
+public class Inventory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "inventory_name", nullable = false, length = 100)
+    private String inventoryName;
+
+    @Column(name = "inventory_code", nullable = false, unique = true, length = 50)
+    private String inventoryCode;
+
+    @Column(name = "current_stock", nullable = false)
+    private int currentStock = 0;   // DB 기본값과 맞추기 위해 초기화
+
+    @Column(name = "available_stock", nullable = false)
+    private int availableStock = 0;
+
+    @Column(name = "warehouse", length = 100)
+    private String warehouse;
+
+    @Column(name = "inbound_date", updatable = false,
+            columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
+    private LocalDateTime inboundDate;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "inventory_status", nullable = false)
+    private InventoryStatus inventoryStatus = InventoryStatus.STABLE;
+
+    @PrePersist
+    protected void onCreate() {
+        if (this.inboundDate == null) {
+            this.inboundDate = LocalDateTime.now();
+        }
+    }
+    // === 생성자 + 빌더 ===
+    @Builder
+    public Inventory(String inventoryName,
+                     String inventoryCode,
+                     int currentStock,
+                     int availableStock,
+                     String warehouse,
+                     InventoryStatus inventoryStatus) {
+        this.inventoryName = inventoryName;
+        this.inventoryCode = inventoryCode;
+        this.currentStock = currentStock;
+        this.availableStock = availableStock;
+        this.warehouse = warehouse;
+        this.inventoryStatus = inventoryStatus != null ? inventoryStatus : InventoryStatus.STABLE;
+    }
+
+    // === 도메인 메서드 ===
+    public void increaseStock(int quantity) {
+        if (quantity <= 0) throw new IllegalArgumentException("입고 수량은 0보다 커야 합니다.");
+        this.currentStock += quantity;
+        this.availableStock += quantity;
+    }
+
+    public void decreaseStock(int quantity) {
+        if (quantity <= 0) throw new IllegalArgumentException("출고 수량은 0보다 커야 합니다.");
+        if (this.availableStock < quantity) throw new IllegalStateException("가용 재고 부족");
+        this.currentStock -= quantity;
+        this.availableStock -= quantity;
+    }
+
+
+    // === Enum ===
+    public enum InventoryStatus {
+        STABLE, NEED_RESTOCK
+    }
+}
+

--- a/src/main/java/com/gearfirst/backend/api/inventory/repository/InventoryRepository.java
+++ b/src/main/java/com/gearfirst/backend/api/inventory/repository/InventoryRepository.java
@@ -1,0 +1,14 @@
+package com.gearfirst.backend.api.inventory.repository;
+
+import com.gearfirst.backend.api.inventory.entity.Inventory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface InventoryRepository extends JpaRepository<Inventory, Long> {
+
+    // 날짜 범위 필터 조회
+    List<Inventory> findByInboundDateBetween(LocalDateTime startDate, LocalDateTime endDate);
+
+}

--- a/src/main/java/com/gearfirst/backend/api/inventory/service/InventoryService.java
+++ b/src/main/java/com/gearfirst/backend/api/inventory/service/InventoryService.java
@@ -1,0 +1,11 @@
+package com.gearfirst.backend.api.inventory.service;
+
+import com.gearfirst.backend.api.inventory.entity.Inventory;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface InventoryService {
+    List<Inventory> getInventories(LocalDate startDate, LocalDate endDate);
+    Inventory getInventory(Long id);
+}

--- a/src/main/java/com/gearfirst/backend/api/inventory/service/InventoryServiceImpl.java
+++ b/src/main/java/com/gearfirst/backend/api/inventory/service/InventoryServiceImpl.java
@@ -1,0 +1,37 @@
+package com.gearfirst.backend.api.inventory.service;
+
+import com.gearfirst.backend.api.inventory.entity.Inventory;
+import com.gearfirst.backend.api.inventory.repository.InventoryRepository;
+import com.gearfirst.backend.common.exception.NotFoundException;
+import com.gearfirst.backend.common.response.ErrorStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class InventoryServiceImpl implements InventoryService {
+
+    private final InventoryRepository inventoryRepository;
+
+    @Override
+    public List<Inventory> getInventories(LocalDate startDate, LocalDate endDate) {
+        if (startDate != null && endDate != null) {
+            return inventoryRepository.findByInboundDateBetween(
+                    startDate.atStartOfDay(),
+                    endDate.atTime(LocalTime.MAX)
+            );
+        }
+        return inventoryRepository.findAll();
+    }
+
+    @Override
+    public Inventory getInventory(Long id) {
+        return inventoryRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException(ErrorStatus.NOT_FOUND_INVENTORY_EXCEPTION.getMessage()));
+
+    }
+}

--- a/src/main/java/com/gearfirst/backend/common/response/ErrorStatus.java
+++ b/src/main/java/com/gearfirst/backend/common/response/ErrorStatus.java
@@ -16,6 +16,7 @@ public enum ErrorStatus {
 
     /** 404 NOT_FOUND */
     NOT_FOUND_MEMBER_EXCEPTION(HttpStatus.NOT_FOUND, "존재하지 않는 사용자 입니다."),
+    NOT_FOUND_INVENTORY_EXCEPTION(HttpStatus.NOT_FOUND, "존재하지 않는 재고입니다."),
 
     /** 500 SERVER_ERROR */
     FAIL_UPLOAD_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR,"파일 업로드 실패하였습니다."),

--- a/src/main/java/com/gearfirst/backend/common/response/SuccessStatus.java
+++ b/src/main/java/com/gearfirst/backend/common/response/SuccessStatus.java
@@ -10,6 +10,8 @@ import org.springframework.http.HttpStatus;
 public enum SuccessStatus {
     /** 200 SUCCESS */
     SEND_SAMPLE_SUCCESS(HttpStatus.OK,"샘플 조회 성공"),
+    GET_INVENTORY_LIST_SUCCESS(HttpStatus.OK,"재고 목록 조회 성공"),
+    GET_INVENTORY_SUCCESS(HttpStatus.OK,"단건 재고 조회 성공"),
 
     /** 201 CREATED */
     CREATE_SAMPLE_SUCCESS(HttpStatus.CREATED, "샘플 등록 성공"),

--- a/src/test/java/com/gearfirst/backend/api/inventory/controller/InventoryControllerTest.java
+++ b/src/test/java/com/gearfirst/backend/api/inventory/controller/InventoryControllerTest.java
@@ -1,0 +1,64 @@
+package com.gearfirst.backend.api.inventory.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gearfirst.backend.api.inventory.entity.Inventory;
+import com.gearfirst.backend.api.inventory.repository.InventoryRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class InventoryControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private InventoryRepository inventoryRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        inventoryRepository.deleteAll();
+        inventoryRepository.save(
+                Inventory.builder()
+                        .inventoryName("브레이크 패드")
+                        .inventoryCode("BP-001")
+                        .currentStock(100)
+                        .availableStock(100)
+                        .warehouse("A창고")
+                        .build()
+        );
+    }
+    @Test
+    void 재고목록조회_API() throws Exception {
+        mockMvc.perform(get("/api/v1/inventory")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data[0].inventoryName").value("브레이크 패드"))
+                .andExpect(jsonPath("$.data[0].currentStock").value(100));
+    }
+
+    @Test
+    void 재고단건조회_API() throws Exception {
+        Inventory inv = inventoryRepository.findAll().get(0);
+
+        mockMvc.perform(get("/api/v1/inventory/" + inv.getId())
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.inventoryCode").value("BP-001"))
+                .andExpect(jsonPath("$.data.inventoryName").value("브레이크 패드"));
+    }
+}

--- a/src/test/java/com/gearfirst/backend/api/inventory/repository/InventoryRepositoryTest.java
+++ b/src/test/java/com/gearfirst/backend/api/inventory/repository/InventoryRepositoryTest.java
@@ -1,0 +1,55 @@
+package com.gearfirst.backend.api.inventory.repository;
+
+import com.gearfirst.backend.api.inventory.entity.Inventory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+class InventoryRepositoryTest {
+
+    @Autowired
+    private InventoryRepository inventoryRepository;
+
+    @Test
+    @DisplayName("입고일자 기준으로 범위 조회가 가능하다")
+    void findByInboundDateBetween() {
+        // given
+        Inventory inv1 = Inventory.builder()
+                .inventoryName("에어필터")
+                .inventoryCode("AF-001")
+                .currentStock(50)
+                .availableStock(50)
+                .warehouse("서울 창고")
+                .inventoryStatus(Inventory.InventoryStatus.STABLE)
+                .build();
+
+        Inventory inv2 = Inventory.builder()
+                .inventoryName("오일필터")
+                .inventoryCode("OF-001")
+                .currentStock(10)
+                .availableStock(10)
+                .warehouse("대전 창고")
+                .inventoryStatus(Inventory.InventoryStatus.NEED_RESTOCK)
+                .build();
+
+        inventoryRepository.save(inv1);
+        inventoryRepository.save(inv2);
+
+        LocalDateTime start = LocalDateTime.now().minusDays(1);
+        LocalDateTime end = LocalDateTime.now().plusDays(1);
+
+        // when
+        List<Inventory> result = inventoryRepository.findByInboundDateBetween(start, end);
+
+        // then
+        assertThat(result).hasSize(2);
+    }
+}

--- a/src/test/java/com/gearfirst/backend/api/inventory/service/InventoryServiceImplTest.java
+++ b/src/test/java/com/gearfirst/backend/api/inventory/service/InventoryServiceImplTest.java
@@ -1,0 +1,92 @@
+package com.gearfirst.backend.api.inventory.service;
+
+import com.gearfirst.backend.api.inventory.entity.Inventory;
+import com.gearfirst.backend.api.inventory.repository.InventoryRepository;
+import com.gearfirst.backend.common.exception.NotFoundException;
+import com.gearfirst.backend.common.response.ErrorStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+class InventoryServiceImplTest {
+    @Mock
+    private InventoryRepository inventoryRepository;
+
+    @InjectMocks
+    private InventoryServiceImpl inventoryService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void 재고_단건조회_성공() {
+        // given
+        Inventory mockInventory = Inventory.builder()
+                .inventoryName("브레이크 패드")
+                .inventoryCode("BP-001")
+                .currentStock(100)
+                .availableStock(100)
+                .warehouse("A창고")
+                .build();
+
+        when(inventoryRepository.findById(1L)).thenReturn(Optional.of(mockInventory));
+
+        // when
+        Inventory result = inventoryService.getInventory(1L);
+
+        // then
+        assertThat(result.getInventoryName()).isEqualTo("브레이크 패드");
+    }
+
+    @Test
+    void 재고_단건조회_실패_NotFound() {
+        // given
+        when(inventoryRepository.findById(999L)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> inventoryService.getInventory(999L))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage(ErrorStatus.NOT_FOUND_INVENTORY_EXCEPTION.getMessage());
+    }
+    @Test
+    void 재고_목록조회_성공() {
+        // given
+        Inventory inv1 = Inventory.builder()
+                .inventoryName("브레이크 패드")
+                .inventoryCode("BP-001")
+                .currentStock(100)
+                .availableStock(100)
+                .warehouse("A창고")
+                .build();
+
+        Inventory inv2 = Inventory.builder()
+                .inventoryName("에어필터")
+                .inventoryCode("AF-001")
+                .currentStock(50)
+                .availableStock(50)
+                .warehouse("B창고")
+                .build();
+
+        when(inventoryRepository.findAll()).thenReturn(List.of(inv1, inv2));
+
+        // when
+        List<Inventory> result = inventoryService.getInventories(null, null);
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result).extracting("inventoryName")
+                .containsExactlyInAnyOrder("브레이크 패드", "에어필터");
+    }
+}


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- Entity
  - `Inventory` 엔티티 생성
  - `@PrePersist` 적용으로 `inboundDate` 자동 세팅
  - 도메인 메서드 추가 (`increaseStock`, `decreaseStock`)

- Repository
  - `JpaRepository` 상속
  - 입고일자 기준 조회 메서드 추가: `findByInboundDateBetween(...)`

- Service
  - `InventoryService` 인터페이스 + 구현체 (`InventoryServiceImpl`)
  - 단일 조회 시 `NotFoundException` 처리 적용
  - 기간별 조회 / 전체 조회 기능 구현

- Controller
  - `/api/v1/inventory` 전체 조회 API
  - `/api/v1/inventory/{id}` 단건 조회 API
  - 응답 DTO(`InventoryResponse`)로 변환 후 `ApiResponse` 포맷으로 반환

- Test
  - Repository 통합테스트 (@DataJpaTest)
  - Service 단위테스트 (Mockito)
  - Controller 통합테스트 (MockMvc)

