### PR TITLE
Feat/#3inventory mysql db로 변경, 재고 조회 api 분리

### DIFF
--- a/src/main/java/com/gearfirst/backend/api/inventory/controller/InventoryController.java
+++ b/src/main/java/com/gearfirst/backend/api/inventory/controller/InventoryController.java
@@ -28,7 +28,7 @@ public class InventoryController {
     @GetMapping
     public ResponseEntity<ApiResponse<List<InventoryResponse>>> getAllInventories(){
 
-        List<Inventory> inventories = inventoryService.getInventories(null, null);
+        List<Inventory> inventories = inventoryService.getAllInventories();
         List<InventoryResponse> responses = inventories.stream()
                 .map(InventoryResponse::fromEntity)
                 .collect(Collectors.toList());
@@ -38,17 +38,18 @@ public class InventoryController {
 
     @Operation(summary = "재고 검색 API", description = "날짜로 필터링 하여 조회합니다.")
     @GetMapping("/search/date")
-    public ResponseEntity<ApiResponse<List<InventoryResponse>>> getInventories(
-            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
-            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate) {
+    public ResponseEntity<ApiResponse<List<InventoryResponse>>> getInventoriesByDate(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate) {
 
-        List<Inventory> inventories = inventoryService.getInventories(startDate, endDate);
+        List<Inventory> inventories = inventoryService.getInventoriesByDate(startDate, endDate);
         List<InventoryResponse> responses = inventories.stream()
                 .map(InventoryResponse::fromEntity)
                 .collect(Collectors.toList());
 
         return ApiResponse.success(SuccessStatus.GET_INVENTORY_LIST_SUCCESS, responses);
     }
+
     @Operation(summary = "재고 단건 조회 API", description = "단건 재고 데이터를 조회합니다.")
     @GetMapping("/{id}")
     public ResponseEntity<ApiResponse<InventoryResponse>> getInventory(@PathVariable Long id) {

--- a/src/main/java/com/gearfirst/backend/api/inventory/controller/InventoryController.java
+++ b/src/main/java/com/gearfirst/backend/api/inventory/controller/InventoryController.java
@@ -1,7 +1,7 @@
 package com.gearfirst.backend.api.inventory.controller;
 
 import com.gearfirst.backend.api.inventory.dto.InventoryResponse;
-import com.gearfirst.backend.api.inventory.entity.Inventory;
+import com.gearfirst.backend.api.inventory.domain.entity.Inventory;
 import com.gearfirst.backend.api.inventory.service.InventoryService;
 import com.gearfirst.backend.common.response.ApiResponse;
 import com.gearfirst.backend.common.response.SuccessStatus;
@@ -13,7 +13,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 

--- a/src/main/java/com/gearfirst/backend/api/inventory/domain/entity/Inventory.java
+++ b/src/main/java/com/gearfirst/backend/api/inventory/domain/entity/Inventory.java
@@ -1,5 +1,6 @@
-package com.gearfirst.backend.api.inventory.entity;
+package com.gearfirst.backend.api.inventory.domain.entity;
 
+import com.gearfirst.backend.api.inventory.domain.enums.InventoryStatus;
 import com.gearfirst.backend.common.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -78,10 +79,5 @@ public class Inventory{
         this.availableStock -= quantity;
     }
 
-
-    // === Enum ===
-    public enum InventoryStatus {
-        STABLE, NEED_RESTOCK
-    }
 }
 

--- a/src/main/java/com/gearfirst/backend/api/inventory/domain/enums/InventoryStatus.java
+++ b/src/main/java/com/gearfirst/backend/api/inventory/domain/enums/InventoryStatus.java
@@ -1,0 +1,5 @@
+package com.gearfirst.backend.api.inventory.domain.enums;
+
+public enum InventoryStatus {
+    STABLE, NEED_RESTOCK
+}

--- a/src/main/java/com/gearfirst/backend/api/inventory/dto/InventoryResponse.java
+++ b/src/main/java/com/gearfirst/backend/api/inventory/dto/InventoryResponse.java
@@ -1,6 +1,6 @@
 package com.gearfirst.backend.api.inventory.dto;
 
-import com.gearfirst.backend.api.inventory.entity.Inventory;
+import com.gearfirst.backend.api.inventory.domain.entity.Inventory;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 

--- a/src/main/java/com/gearfirst/backend/api/inventory/repository/InventoryRepository.java
+++ b/src/main/java/com/gearfirst/backend/api/inventory/repository/InventoryRepository.java
@@ -1,6 +1,6 @@
 package com.gearfirst.backend.api.inventory.repository;
 
-import com.gearfirst.backend.api.inventory.entity.Inventory;
+import com.gearfirst.backend.api.inventory.domain.entity.Inventory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDateTime;

--- a/src/main/java/com/gearfirst/backend/api/inventory/service/InventoryService.java
+++ b/src/main/java/com/gearfirst/backend/api/inventory/service/InventoryService.java
@@ -6,6 +6,7 @@ import java.time.LocalDate;
 import java.util.List;
 
 public interface InventoryService {
-    List<Inventory> getInventories(LocalDate startDate, LocalDate endDate);
+    List<Inventory> getAllInventories();
+    List<Inventory> getInventoriesByDate(LocalDate startDate, LocalDate endDate);
     Inventory getInventory(Long id);
 }

--- a/src/main/java/com/gearfirst/backend/api/inventory/service/InventoryService.java
+++ b/src/main/java/com/gearfirst/backend/api/inventory/service/InventoryService.java
@@ -1,6 +1,6 @@
 package com.gearfirst.backend.api.inventory.service;
 
-import com.gearfirst.backend.api.inventory.entity.Inventory;
+import com.gearfirst.backend.api.inventory.domain.entity.Inventory;
 
 import java.time.LocalDate;
 import java.util.List;

--- a/src/main/java/com/gearfirst/backend/api/inventory/service/InventoryServiceImpl.java
+++ b/src/main/java/com/gearfirst/backend/api/inventory/service/InventoryServiceImpl.java
@@ -1,6 +1,6 @@
 package com.gearfirst.backend.api.inventory.service;
 
-import com.gearfirst.backend.api.inventory.entity.Inventory;
+import com.gearfirst.backend.api.inventory.domain.entity.Inventory;
 import com.gearfirst.backend.api.inventory.repository.InventoryRepository;
 import com.gearfirst.backend.common.exception.NotFoundException;
 import com.gearfirst.backend.common.response.ErrorStatus;

--- a/src/main/java/com/gearfirst/backend/api/inventory/service/InventoryServiceImpl.java
+++ b/src/main/java/com/gearfirst/backend/api/inventory/service/InventoryServiceImpl.java
@@ -18,14 +18,20 @@ public class InventoryServiceImpl implements InventoryService {
     private final InventoryRepository inventoryRepository;
 
     @Override
-    public List<Inventory> getInventories(LocalDate startDate, LocalDate endDate) {
-        if (startDate != null && endDate != null) {
-            return inventoryRepository.findByInboundDateBetween(
-                    startDate.atStartOfDay(),
-                    endDate.atTime(LocalTime.MAX)
-            );
-        }
+    public List<Inventory> getAllInventories(){
         return inventoryRepository.findAll();
+    }
+
+    @Override
+    public List<Inventory> getInventoriesByDate(LocalDate startDate, LocalDate endDate) {
+        if (startDate.isAfter(endDate)) {
+            throw new IllegalArgumentException("시작일은 종료일보다 이후일 수 없습니다.");
+        }
+
+        return inventoryRepository.findByInboundDateBetween(
+                startDate.atStartOfDay(),
+                endDate.atTime(LocalTime.MAX)
+        );
     }
 
     @Override

--- a/src/test/java/com/gearfirst/backend/api/inventory/controller/InventoryControllerTest.java
+++ b/src/test/java/com/gearfirst/backend/api/inventory/controller/InventoryControllerTest.java
@@ -1,7 +1,7 @@
 package com.gearfirst.backend.api.inventory.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.gearfirst.backend.api.inventory.entity.Inventory;
+import com.gearfirst.backend.api.inventory.domain.entity.Inventory;
 import com.gearfirst.backend.api.inventory.repository.InventoryRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -11,8 +11,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import java.time.LocalDateTime;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;

--- a/src/test/java/com/gearfirst/backend/api/inventory/controller/InventoryControllerTest.java
+++ b/src/test/java/com/gearfirst/backend/api/inventory/controller/InventoryControllerTest.java
@@ -2,6 +2,7 @@ package com.gearfirst.backend.api.inventory.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.gearfirst.backend.api.inventory.domain.entity.Inventory;
+import com.gearfirst.backend.api.inventory.domain.enums.InventoryStatus;
 import com.gearfirst.backend.api.inventory.repository.InventoryRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -11,7 +12,9 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import java.time.LocalDateTime;
+import java.util.List;
 
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -38,6 +41,7 @@ class InventoryControllerTest {
                         .currentStock(100)
                         .availableStock(100)
                         .warehouse("A창고")
+                        .inventoryStatus(InventoryStatus.STABLE)
                         .build()
         );
         inventoryRepository.save(
@@ -47,6 +51,7 @@ class InventoryControllerTest {
                         .currentStock(0)
                         .availableStock(0)
                         .warehouse("B창고")
+                        .inventoryStatus(InventoryStatus.STABLE)
                         .build()
         );
     }
@@ -56,8 +61,8 @@ class InventoryControllerTest {
         mockMvc.perform(get("/api/v1/inventory")
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data[0].inventoryName").value("브레이크 패드"))
-                .andExpect(jsonPath("$.data[1].inventoryName").value("에어필터"));
+                .andExpect(jsonPath("$.data[*].inventoryName")
+                        .value(containsInAnyOrder("브레이크 패드","에어필터")));
     }
 
     @Test
@@ -70,13 +75,14 @@ class InventoryControllerTest {
                         .param("endDate", endDate)
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data[0].inventoryCode").value("BP-001"))
-                .andExpect(jsonPath("$.data[1].inventoryCode").value("AF-001"));
+                .andExpect(jsonPath("$.data[*].inventoryCode")
+                        .value(containsInAnyOrder("BP-001", "AF-001")));
     }
 
     @Test
     void 재고단건조회_API() throws Exception {
-        Inventory inv = inventoryRepository.findAll().get(0);
+        List<Inventory> inventories = inventoryRepository.findAll();
+        Inventory inv = inventories.get(0);
 
         mockMvc.perform(get("/api/v1/inventory/" + inv.getId())
                         .accept(MediaType.APPLICATION_JSON))

--- a/src/test/java/com/gearfirst/backend/api/inventory/repository/InventoryRepositoryTest.java
+++ b/src/test/java/com/gearfirst/backend/api/inventory/repository/InventoryRepositoryTest.java
@@ -1,6 +1,7 @@
 package com.gearfirst.backend.api.inventory.repository;
 
-import com.gearfirst.backend.api.inventory.entity.Inventory;
+import com.gearfirst.backend.api.inventory.domain.entity.Inventory;
+import com.gearfirst.backend.api.inventory.domain.enums.InventoryStatus;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -10,7 +11,6 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 @DataJpaTest
 class InventoryRepositoryTest {
@@ -28,7 +28,7 @@ class InventoryRepositoryTest {
                 .currentStock(50)
                 .availableStock(50)
                 .warehouse("서울 창고")
-                .inventoryStatus(Inventory.InventoryStatus.STABLE)
+                .inventoryStatus(InventoryStatus.STABLE)
                 .build();
 
         Inventory inv2 = Inventory.builder()
@@ -37,7 +37,7 @@ class InventoryRepositoryTest {
                 .currentStock(10)
                 .availableStock(10)
                 .warehouse("대전 창고")
-                .inventoryStatus(Inventory.InventoryStatus.NEED_RESTOCK)
+                .inventoryStatus(InventoryStatus.NEED_RESTOCK)
                 .build();
 
         inventoryRepository.save(inv1);

--- a/src/test/java/com/gearfirst/backend/api/inventory/repository/InventoryRepositoryTest.java
+++ b/src/test/java/com/gearfirst/backend/api/inventory/repository/InventoryRepositoryTest.java
@@ -43,8 +43,8 @@ class InventoryRepositoryTest {
         inventoryRepository.save(inv1);
         inventoryRepository.save(inv2);
 
-        LocalDateTime start = LocalDateTime.now().minusDays(1);
-        LocalDateTime end = LocalDateTime.now().plusDays(1);
+        LocalDateTime start = LocalDateTime.now().minusDays(1); //현재 시간에서 하루를 빼는 메서드
+        LocalDateTime end = LocalDateTime.now().plusDays(1);    //현재 시간에서 하루를 더하는 메서드
 
         // when
         List<Inventory> result = inventoryRepository.findByInboundDateBetween(start, end);

--- a/src/test/java/com/gearfirst/backend/api/inventory/service/InventoryServiceImplTest.java
+++ b/src/test/java/com/gearfirst/backend/api/inventory/service/InventoryServiceImplTest.java
@@ -1,6 +1,6 @@
 package com.gearfirst.backend.api.inventory.service;
 
-import com.gearfirst.backend.api.inventory.entity.Inventory;
+import com.gearfirst.backend.api.inventory.domain.entity.Inventory;
 import com.gearfirst.backend.api.inventory.repository.InventoryRepository;
 import com.gearfirst.backend.common.exception.NotFoundException;
 import com.gearfirst.backend.common.response.ErrorStatus;
@@ -15,7 +15,6 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
 
 class InventoryServiceImplTest {

--- a/src/test/java/com/gearfirst/backend/api/inventory/service/InventoryServiceImplTest.java
+++ b/src/test/java/com/gearfirst/backend/api/inventory/service/InventoryServiceImplTest.java
@@ -1,6 +1,7 @@
 package com.gearfirst.backend.api.inventory.service;
 
 import com.gearfirst.backend.api.inventory.domain.entity.Inventory;
+import com.gearfirst.backend.api.inventory.domain.enums.InventoryStatus;
 import com.gearfirst.backend.api.inventory.repository.InventoryRepository;
 import com.gearfirst.backend.common.exception.NotFoundException;
 import com.gearfirst.backend.common.response.ErrorStatus;
@@ -10,12 +11,19 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;       //특정 mock 객체가 어떤 메서드를 몇번 호출했는지 검증
+import static org.mockito.Mockito.times;        //호출 횟수를 지정하는 helper 메서드
+import static org.mockito.Mockito.when;         //Mock 동작을 세팅하는 Stubbing 메서드
+
 
 class InventoryServiceImplTest {
     @Mock
@@ -60,7 +68,7 @@ class InventoryServiceImplTest {
                 .hasMessage(ErrorStatus.NOT_FOUND_INVENTORY_EXCEPTION.getMessage());
     }
     @Test
-    void 재고_목록조회_성공() {
+    void 재고_전체목록조회_성공() {
         // given
         Inventory inv1 = Inventory.builder()
                 .inventoryName("브레이크 패드")
@@ -81,11 +89,59 @@ class InventoryServiceImplTest {
         when(inventoryRepository.findAll()).thenReturn(List.of(inv1, inv2));
 
         // when
-        List<Inventory> result = inventoryService.getInventories(null, null);
+        List<Inventory> result = inventoryService.getAllInventories();
 
         // then
         assertThat(result).hasSize(2);
         assertThat(result).extracting("inventoryName")
                 .containsExactlyInAnyOrder("브레이크 패드", "에어필터");
+    }
+
+    /**
+     * inboundDate는 DB 에서 INSERT 할 때 자동 세팅 되게 되어있음
+     * Mock 테스트에서는 DB에 개입하지 않으므로 inboundDate ==null 상태
+     * 그래서 Repository 메서드 호출 여부만 검증
+     */
+    @Test
+    void 재고_날짜_필터링조회_성공() {
+        // given
+        LocalDate startDate = LocalDate.of(2025, 1, 1);
+        LocalDate endDate = LocalDate.of(2025, 1, 31);
+
+        Inventory inv1 = Inventory.builder()
+                .inventoryName("브레이크 패드")
+                .inventoryCode("BP-001")
+                .currentStock(100)
+                .availableStock(100)
+                .warehouse("A창고")
+                .inventoryStatus(InventoryStatus.STABLE)
+                .build();
+
+        Inventory inv2 = Inventory.builder()
+                .inventoryName("에어필터")
+                .inventoryCode("AF-001")
+                .currentStock(50)
+                .availableStock(50)
+                .warehouse("B창고")
+                .inventoryStatus(InventoryStatus.STABLE)
+                .build();
+
+        //inventoryRepository.findByInboundDateBetween()이 호출되면 무조건 List.of(inv1,inv2)를 리턴하도록 미리 지정
+        when(inventoryRepository.findByInboundDateBetween(any(), any()))
+                .thenReturn(List.of(inv1, inv2));
+
+        // when
+        List<Inventory> result = inventoryService.getInventoriesByDate(startDate,endDate);
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result).extracting("inventoryName") //리스트 안의 객체에서 inventoryName 속성만 추출해서 비교
+                .containsExactlyInAnyOrder("브레이크 패드", "에어필터");
+
+        verify(inventoryRepository, times(1)) //해당 목 객체가 1번 호출됐는지 확인
+                .findByInboundDateBetween(
+                        eq(startDate.atStartOfDay()),
+                        eq(endDate.atTime(LocalTime.MAX))
+                );
     }
 }


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #3 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 기존에 하나의 API에서 처리하던 "전체 조회"와 "날짜 필터링 조회"를 각각 별도의 API로 분리
- Inventory 엔티티 내부에 선언되어 있던 `재고 상태(InventoryStatus)` enum을 별도의 파일로 분리


